### PR TITLE
Compilation (./): add stb_image to the cmake compilation

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(r-type_client GameEngine glad glfw glm imgui)
 
 target_include_directories(r-type_client PRIVATE ${glad_INCLUDE_DIRS})
 target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/GLAD/include)
+target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/stb_image)
 target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
 target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
 target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)

--- a/Examples/Application/CMakeLists.txt
+++ b/Examples/Application/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(application GameEngine glad glfw glm imgui)
 
 target_include_directories(application PRIVATE ${glad_INCLUDE_DIRS})
 target_include_directories(application PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/GLAD/include)
+target_include_directories(application PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/stb_image)
 target_include_directories(application PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
 target_include_directories(application PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
 target_include_directories(application PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)

--- a/Examples/ApplicationWithSpriteRenderer/CMakeLists.txt
+++ b/Examples/ApplicationWithSpriteRenderer/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(applicationRenderer GameEngine glad glfw glm imgui)
 
 target_include_directories(applicationRenderer PRIVATE ${glad_INCLUDE_DIRS})
 target_include_directories(applicationRenderer PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/GLAD/include)
+target_include_directories(applicationRenderer PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/stb_image)
 target_include_directories(applicationRenderer PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
 target_include_directories(applicationRenderer PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
 target_include_directories(applicationRenderer PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)

--- a/Examples/Entity-Component-System/CMakeLists.txt
+++ b/Examples/Entity-Component-System/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(ecs GameEngine glad glfw glm imgui)
 
 target_include_directories(ecs PRIVATE ${glad_INCLUDE_DIRS})
 target_include_directories(ecs PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/GLAD/include)
+target_include_directories(ecs PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/stb_image)
 target_include_directories(ecs PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
 target_include_directories(ecs PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
 target_include_directories(ecs PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)

--- a/GameEngine/CMakeLists.txt
+++ b/GameEngine/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(GameEngine STATIC ${SOURCES_GAME_ENGINE})
 
 target_include_directories(GameEngine PRIVATE ${INCLUDE_DIRS_GAME_ENGINE})
 target_include_directories(GameEngine PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/GLAD/include)
+target_include_directories(GameEngine PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/stb_image)
 target_include_directories(GameEngine PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
 target_include_directories(GameEngine PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
 target_include_directories(GameEngine PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)

--- a/GameEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/GameEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -7,7 +7,7 @@
 
 // External includes
 #define STB_IMAGE_IMPLEMENTATION
-    #include <stb_image.h>
+    #include "stb_image.h"
 
 // OpenGL
 #include "OpenGLTexture.hpp"

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -40,9 +40,10 @@ target_link_libraries(r-type_server GameEngine glad glfw glm imgui)
 
 target_include_directories(r-type_server PRIVATE ${glad_INCLUDE_DIRS})
 target_include_directories(r-type_server PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/GLAD/include)
-target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
-target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
-target_include_directories(r-type_client PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)
+target_include_directories(r-type_server PRIVATE ${CMAKE_BINARY_DIR}/_deps/opengl-src/stb_image)
+target_include_directories(r-type_server PRIVATE ${CMAKE_BINARY_DIR}/_deps/glfw-src/include)
+target_include_directories(r-type_server PRIVATE ${CMAKE_BINARY_DIR}/_deps/glm-src)
+target_include_directories(r-type_server PRIVATE ${CMAKE_BINARY_DIR}/_deps/imgui-src)
 
 set_target_properties(r-type_server PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../


### PR DESCRIPTION
## Pull Request

### Description
Fix the compilation of the R-Type by adding stb_image.

### Changes Made
Add 'target_include_directories' of stb_image in all CMakeLists.txt.

### Testing
I Recompiled and it works !

### Checklist
- [x] I have tested the compilation