### PR TITLE
Fix (./Exodia/ECS/World): remove the segfault on entity delete

### DIFF
--- a/Examples/DefaultSystem/src/Script/Player.hpp
+++ b/Examples/DefaultSystem/src/Script/Player.hpp
@@ -45,11 +45,15 @@ namespace Exodia {
             {
                 EXODIA_INFO("Collision with {0}", entity->GetComponent<TagComponent>().Get().Tag);
 
-                auto &body = GetComponent<RigidBody2DComponent>().Get();
+                auto body = GetComponent<RigidBody2DComponent>();
 
-                if (body.Type == RigidBody2DComponent::BodyType::Dynamic)
-                    body.Velocity = glm::vec2{ 0.0f, 0.0f };
-                body.GravityScale = 0.0f;
+                if (body) {
+                    auto &bodyC = body.Get();
+
+                    if (bodyC.Type == RigidBody2DComponent::BodyType::Dynamic)
+                        bodyC.Velocity = glm::vec2{ 0.0f, 0.0f };
+                    bodyC.GravityScale = 0.0f;
+                }
             }
 
         ////////////////

--- a/GameEngine/src/Exodia/ECS/System/Collision/CollisionSystem.cpp
+++ b/GameEngine/src/Exodia/ECS/System/Collision/CollisionSystem.cpp
@@ -251,6 +251,11 @@ namespace Exodia {
 
     void CollisionSystem::CompareCollisions(const std::vector<std::pair<Entity *, Entity *>> &collisions)
     {
+        if (collisions.empty()) {
+            _LastCollisions.clear();
+            return;
+        }
+
         if (_LastCollisions.empty()) {
             for (auto &collision : collisions)
                 EmitOnCollisionEnterEvent(collision.first, collision.second);
@@ -265,8 +270,10 @@ namespace Exodia {
                     }
                 }
 
-                if (found == false)
+                if (found == false) {
+                    EXODIA_CORE_INFO("Collision between {0} and {1}", collision.first->GetComponent<TagComponent>().Get().Tag, collision.second->GetComponent<TagComponent>().Get().Tag);
                     EmitOnCollisionEnterEvent(collision.first, collision.second);
+                }
             }
         }
 

--- a/GameEngine/src/Exodia/ECS/World/World.cpp
+++ b/GameEngine/src/Exodia/ECS/World/World.cpp
@@ -112,32 +112,30 @@ namespace Exodia {
         if (entity == nullptr)
             return;
 
-        if (entity->IsPendingDestroy()) {
+        if (entity->IsPendingDestroy() == false) {
             if (immediate) {
+                if (_IndexToUUIDMap.find(entity->GetEntityID()) != _IndexToUUIDMap.end())
+                    _IndexToUUIDMap.erase(_IndexToUUIDMap.find(entity->GetEntityID()));
+
                 _Entities.erase(std::remove(_Entities.begin(), _Entities.end(), entity), _Entities.end());
 
-                _IndexToUUIDMap.erase(_IndexToUUIDMap.find(entity->GetEntityID()));
-
-                SortUUIDMap();
-
-                std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
-                std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
+                //std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
+                //std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
             }
+            entity->SetPendingDestroy(true);
             return;
         }
-        entity->SetPendingDestroy(true);
 
         Emit<Events::OnEntityDestroyed>({ entity });
 
         if (immediate) {
+            if (_IndexToUUIDMap.find(entity->GetEntityID()) != _IndexToUUIDMap.end())
+                _IndexToUUIDMap.erase(_IndexToUUIDMap.find(entity->GetEntityID()));
+
             _Entities.erase(std::remove(_Entities.begin(), _Entities.end(), entity), _Entities.end());
 
-            _IndexToUUIDMap.erase(_IndexToUUIDMap.find(entity->GetEntityID()));
-
-            SortUUIDMap();
-
-            std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
-            std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
+            //std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
+            //std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
         }
     }
 
@@ -147,12 +145,8 @@ namespace Exodia {
 
         _Entities.erase(std::remove_if(_Entities.begin(), _Entities.end(), [&, this](Entity *entity) {
             if (entity->IsPendingDestroy()) {
-                _IndexToUUIDMap.erase(_IndexToUUIDMap.find(entity->GetEntityID()));
-
-                SortUUIDMap();
-
-                std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
-                std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
+                //std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
+                //std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
 
                 count++;
 
@@ -173,8 +167,6 @@ namespace Exodia {
                 Emit<Events::OnEntityDestroyed>({ entity });
             }
             _IndexToUUIDMap.erase(_IndexToUUIDMap.find(entity->GetEntityID()));
-
-            SortUUIDMap();
 
             std::allocator_traits<EntityAllocator>::destroy(_EntityAllocator, entity);
             std::allocator_traits<EntityAllocator>::deallocate(_EntityAllocator, entity, 1);
@@ -257,18 +249,6 @@ namespace Exodia {
         for (auto *entity : _MergedEntities)
             _Entities.push_back(entity);
         _MergedEntities.clear();
-    }
-
-    void World::SortUUIDMap()
-    {
-        std::unordered_map<uint64_t, uint64_t> newMap;
-        uint64_t index = 0;
-
-        for (auto &pair : _IndexToUUIDMap) {
-            newMap[index] = pair.second;
-            index++;
-        }
-        _IndexToUUIDMap = newMap;
     }
 
     ///////////////////////

--- a/GameEngine/src/Exodia/ECS/World/World.hpp
+++ b/GameEngine/src/Exodia/ECS/World/World.hpp
@@ -155,7 +155,6 @@ namespace Exodia {
 
         private:
             void MergeEntities();
-            void SortUUIDMap();
 
         ///////////////////////
         // Getters & Setters //


### PR DESCRIPTION
## Pull Request

### Description
Change due to a segfault when entity got deleted during the world process.

### Changes Made
Optimisation : Remove the sort uuid map.
Crash : Put the deallocate function in comment.

### Testing
Testing destroy in a script for check the kill during the problem no more cause problem.
The compilation work well.

### Checklist
- [x]  I have tested these changes thoroughly.