### PR TITLE
Fix (./GameEngine/Exodia/ECS/World): now we can create entity with UUID

### DIFF
--- a/Examples/Entity-Component-System/README.md
+++ b/Examples/Entity-Component-System/README.md
@@ -110,6 +110,7 @@ entity->AddComponent<Health>();
 ```
 
 Note `CreateEntity()` returns a pointer to the entity, know that this entity have default component (TagComponent, IDComponent, TransformComponent).
+Note `CreateEntity()` you can provides a name for the entity or a uuid.
 Note `AddComponent()` can take any arguments that the component's constructor takes, so you can do this instead:
 
 ```cpp

--- a/GameEngine/src/Exodia/ECS/Entity/Entity.cpp
+++ b/GameEngine/src/Exodia/ECS/Entity/Entity.cpp
@@ -15,7 +15,7 @@ namespace Exodia {
 
     Entity::Entity() {};
 
-    Entity::Entity(World * world, uint64_t id) : _World(world), _ID(id), _PendingDestroy(false) {};
+    Entity::Entity(World *world, uint64_t id) : _World(world), _ID(id), _PendingDestroy(false) {};
 
     Entity::~Entity()
     {
@@ -40,12 +40,12 @@ namespace Exodia {
     // Getters & Setters //
     ///////////////////////
 
-    World * Entity::GetWorld() const
+    World *Entity::GetWorld() const
     {
         return _World;
     }
 
-    void Entity::SetWorld(World * world)
+    void Entity::SetWorld(World *world)
     {
         _World = world;
     }

--- a/GameEngine/src/Exodia/ECS/Entity/Entity.hpp
+++ b/GameEngine/src/Exodia/ECS/Entity/Entity.hpp
@@ -48,7 +48,7 @@ namespace Exodia {
         public:
 
             Entity();
-            Entity(World * world, uint64_t id = UUID());
+            Entity(World *world, uint64_t id = UUID());
 
             ~Entity();
 

--- a/GameEngine/src/Exodia/ECS/World/World.cpp
+++ b/GameEngine/src/Exodia/ECS/World/World.cpp
@@ -85,6 +85,27 @@ namespace Exodia {
         return entity;
     }
 
+    Entity *World::CreateNewEntity(const UUID &uuid, const std::string &name)
+    {
+        Entity *entity = std::allocator_traits<EntityAllocator>::allocate(_EntityAllocator, 1);
+
+        std::allocator_traits<EntityAllocator>::construct(_EntityAllocator, entity, this, uuid);
+
+        _IndexToUUIDMap[GetCount() + _MergedEntities.size()] = uuid;
+
+        entity->AddComponent<IDComponent>(uuid);
+        entity->AddComponent<TransformComponent>();
+        auto tag = entity->AddComponent<TagComponent>();
+
+        tag.Get().Tag = name.empty() ? "Entity" : name;
+
+        _MergedEntities.push_back(entity);
+
+        Emit<Events::OnEntityCreated>({ entity });
+
+        return entity;
+    }
+
     Entity *World::CreateEntity(const std::string &name)
     {
         Entity *entity = std::allocator_traits<EntityAllocator>::allocate(_EntityAllocator, 1);
@@ -95,6 +116,27 @@ namespace Exodia {
         _IndexToUUIDMap[GetCount()] = entityID;
 
         entity->AddComponent<IDComponent>(entityID);
+        entity->AddComponent<TransformComponent>();
+        auto tag = entity->AddComponent<TagComponent>();
+
+        tag.Get().Tag = name.empty() ? "Entity" : name;
+
+        _Entities.push_back(entity);
+
+        Emit<Events::OnEntityCreated>({ entity });
+
+        return entity;
+    }
+
+    Entity *World::CreateEntity(const UUID &uuid, const std::string &name)
+    {
+        Entity *entity = std::allocator_traits<EntityAllocator>::allocate(_EntityAllocator, 1);
+
+        std::allocator_traits<EntityAllocator>::construct(_EntityAllocator, entity, this, uuid);
+
+        _IndexToUUIDMap[GetCount()] = uuid;
+
+        entity->AddComponent<IDComponent>(uuid);
         entity->AddComponent<TransformComponent>();
         auto tag = entity->AddComponent<TagComponent>();
 

--- a/GameEngine/src/Exodia/ECS/World/World.hpp
+++ b/GameEngine/src/Exodia/ECS/World/World.hpp
@@ -71,7 +71,10 @@ namespace Exodia {
             void DestroyWorld();
 
             Entity *CreateEntity(const std::string &name = std::string());
+            Entity *CreateEntity(const UUID &uuid, const std::string &name = std::string());
+
             Entity *CreateNewEntity(const std::string &name = std::string());
+            Entity *CreateNewEntity(const UUID &uuid, const std::string &name = std::string());
 
             void DestroyEntity(Entity *entity, bool immediate = false);
 


### PR DESCRIPTION
## Pull Request

### Description
Fix the world for allow the user to create entity with an id.

### Changes Made
Add two function for create entity with uuid.

### Testing
Compilation work.
Examples with ecs work.

### Checklist
- [x] I have tested these changes thoroughly.