### PR TITLE
fix (GameEngine/ && Exodia/): fix compilation of game editor

### DIFF
--- a/Examples/ImGui/Docking/README.md
+++ b/Examples/ImGui/Docking/README.md
@@ -113,11 +113,11 @@ class StatImGui {
 
             ImGui::Begin("Stats");
 
-            ImGui::Text("Renderer2D Stats:");
-            ImGui::Text("Draw Calls: %d", stats.DrawCalls);
-            ImGui::Text("Quads: %d", stats.QuadCount);
-            ImGui::Text("Vertices: %d", stats.GetTotalVertexCount());
-            ImGui::Text("Indices: %d", stats.GetTotalIndexCount());
+            ImGui::TextUnformatted("Renderer2D Stats:");
+            ImGui::TextUnformatted("Draw Calls: %d", stats.DrawCalls);
+            ImGui::TextUnformatted("Quads: %d", stats.QuadCount);
+            ImGui::TextUnformatted("Vertices: %d", stats.GetTotalVertexCount());
+            ImGui::TextUnformatted("Indices: %d", stats.GetTotalIndexCount());
 
             ImGui::End();
         }

--- a/Examples/ImGui/Docking/src/StatImGui.hpp
+++ b/Examples/ImGui/Docking/src/StatImGui.hpp
@@ -34,7 +34,7 @@ namespace Exodia {
 
                 ImGui::Begin("Stats");
 
-                ImGui::Text("Renderer2D Stats:");
+                ImGui::TextUnformatted("Renderer2D Stats:");
                 ImGui::Text("Draw Calls: %d", stats.DrawCalls);
                 ImGui::Text("Quads: %d", stats.QuadCount);
                 ImGui::Text("Vertices: %d", stats.GetTotalVertexCount());

--- a/Exodia/src/Panel/ContentBrowser/ContentBrowser.cpp
+++ b/Exodia/src/Panel/ContentBrowser/ContentBrowser.cpp
@@ -135,7 +135,7 @@ namespace Exodia {
                 }
             }
 
-            ImGui::TextWrapped(filename.c_str());
+            ImGui::TextWrapped("%s", filename.c_str());
             ImGui::NextColumn();
             ImGui::PopID();
         }

--- a/Exodia/src/Panel/SceneHierarchy/SceneHierarchy.cpp
+++ b/Exodia/src/Panel/SceneHierarchy/SceneHierarchy.cpp
@@ -81,7 +81,7 @@ namespace Exodia {
 
             flags |= ImGuiTreeNodeFlags_SpanAvailWidth;
 
-            bool opened = ImGui::TreeNodeEx((void *)(uint64_t)(uint32_t)(*entity), flags, tag.Tag.c_str());
+            bool opened = ImGui::TreeNodeEx((void *)(uint64_t)(uint32_t)(*entity), flags, "%s", tag.Tag.c_str());
 
             if (ImGui::IsItemClicked())
                 _SelectedEntity = entity;
@@ -96,7 +96,7 @@ namespace Exodia {
 
             flags |= ImGuiTreeNodeFlags_SpanAvailWidth;
 
-            ImGui::TreeNodeEx((void *)(uint64_t)(uint32_t)(*entity), flags, tag.Tag.c_str());
+            ImGui::TreeNodeEx((void *)(uint64_t)(uint32_t)(*entity), flags, "%s", tag.Tag.c_str());
 
             if (ImGui::IsItemClicked())
                 _SelectedEntity = entity;

--- a/GameEngine/src/Exodia/ECS/Component/DefaultComponents/RendererComponents.hpp
+++ b/GameEngine/src/Exodia/ECS/Component/DefaultComponents/RendererComponents.hpp
@@ -146,7 +146,7 @@ namespace Exodia {
                     Texture->SetTexture(AssetHandle(0));
             }
             ImGui::SameLine();
-            ImGui::Text("Texture");
+            ImGui::TextUnformatted("Texture");
 
             ImGui::DragFloat("Tiling Factor", &TilingFactor, 0.1f, 0.0f, 100.0f);
         }

--- a/GameEngine/src/Exodia/ECS/Component/DefaultComponents/ScriptComponent.hpp
+++ b/GameEngine/src/Exodia/ECS/Component/DefaultComponents/ScriptComponent.hpp
@@ -91,7 +91,7 @@ namespace Exodia {
                     ImGui::EndPopup();
                 }
             } else {
-                ImGui::Text("Script: %s", Name.c_str());
+                ImGui::TextUnformatted("Script: %s", Name.c_str());
 
                 ImGui::SameLine();
 

--- a/GameEngine/src/Exodia/ImGui/ImGuiToolsUI.hpp
+++ b/GameEngine/src/Exodia/ImGui/ImGuiToolsUI.hpp
@@ -73,7 +73,7 @@ namespace Exodia {
         ImGui::PushID(label.c_str());
         ImGui::Columns(2);
         ImGui::SetColumnWidth(0, columnWidth);
-        ImGui::Text(label.c_str());
+        ImGui::TextUnformatted(label.c_str());
         ImGui::NextColumn();
         ImGui::PushMultiItemsWidths(3, ImGui::CalcItemWidth());
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{ 0, 0 });


### PR DESCRIPTION
## Pull Request

### Description
Fix compilation

### Related Issue(s)
Please list any related issue(s) or feature request(s) that are addressed by this pull request. Use the following format: "Fixes #IssueNumber".

### Changes Made
Change ImGui::Text into ImGui::TextUnformatted if the string doesn't contain flags (ex: "Hello %s", "World")
Change ImGui::TreeNodeEx((void *)(uint64_t)(uint32_t)(*entity), flags, tag.Tag.c_str()) 
       into ImGui::TreeNodeEx((void *)(uint64_t)(uint32_t)(*entity), flags, "%s", tag.Tag.c_str());


### Testing
Testing the compilation with bash script

### Checklist
- [X] I have tested these changes thoroughly.
- [X] The code follows the project's style guide and coding conventions.
- [X] I have updated the relevant documentation (if applicable).
- [X] All tests passed successfully.
- [X] I have checked for any potential conflicts with other branches.

### Definition of Done
The game-editor compiles now